### PR TITLE
The library generate mocha tester errors

### DIFF
--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -133,9 +133,9 @@ OpenTokSDK.prototype.generate_token = function(ops){
   }
 
   // validate partner id
-  subSessionId = sessionId.substring(2);
+  var subSessionId = sessionId.substring(2);
   subSessionId = subSessionId.replace(/-/g, "+").replace(/_/g, "/");
-  decodedSessionId = new Buffer(subSessionId, "base64").toString("ascii").split("~");
+  var decodedSessionId = new Buffer(subSessionId, "base64").toString("ascii").split("~");
   for(var i = 0; i < decodedSessionId.length; i++){
     if (decodedSessionId && decodedSessionId.length > 1){
       break
@@ -224,7 +224,7 @@ OpenTokSDK.prototype.createSession = function(ipPassthru, properties, callback){
 OpenTokSDK.prototype._signString = function(string, secret){
   var hmac = crypto.createHmac('sha1',secret)
   hmac.update(string)
-  return hmac.digest(encoding='hex')
+  return hmac.digest('hex')
 }
 
 OpenTokSDK.prototype._doRequest = function(params, callback){


### PR DESCRIPTION
I'm using mocha to test my code which uses your library. 
Unfortunately you don't use var prefix in some places where you declare local variables what causes errors like this one:
Error: global leaks detected: subSessionId, encoding

My pull corrects that issue.
