### PR TITLE
Use routed as the default way to create a session

### DIFF
--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -440,7 +440,7 @@ OpenTok.prototype.createSession = function (opts, callback) {
   _.pick(_.defaults(opts, { mediaMode: 'relayed', archiveMode: 'manual' }),
         'mediaMode', 'archiveMode', 'location');
   if (opts.mediaMode !== 'routed' && opts.mediaMode !== 'relayed') {
-    opts.mediaMode = 'relayed';
+    opts.mediaMode = 'routed';
   }
   if (opts.archiveMode !== 'manual' && opts.archiveMode !== 'always') {
     opts.archiveMode = 'manual';


### PR DESCRIPTION
Should the default value be `routed` if it's not specified?

#### What is this PR doing?


#### How should this be manually tested?


#### What are the relevant tickets?

