### PR TITLE
Adding initialLayoutClassList for layout control of broadcasts & archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Once a Session is created, you can start generating Tokens for clients to use wh
 You can generate a token by calling the `opentok.generateToken(sessionId, options)` method. Another
 way is to call the `session.generateToken(options)` method of a Session object. The `options`
 parameter is an optional object used to set the role, expire time, and connection data of the Token.
+For layout control in archives and broadcasts, the initial layout class list of streams published
+from connections using this token can be set as well.
 
 ```javascript
 // Generate a Token from just a sessionId (fetched from a database)
@@ -89,9 +91,10 @@ token = session.generateToken();
 
 // Set some options in a Token
 token = session.generateToken({
-  role :       'moderator',
-  expireTime : (new Date().getTime() / 1000)+(7 * 24 * 60 * 60), // in one week
-  data :       'name=Johnny'
+  role :                   'moderator',
+  expireTime :             (new Date().getTime() / 1000)+(7 * 24 * 60 * 60), // in one week
+  data :                   'name=Johnny',
+  initialLayoutClassList : ['focus']
 });
 ```
 

--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -551,13 +551,20 @@ OpenTok.prototype.generateToken = function (sessionId, opts) {
   if (opts.data) {
     opts.connection_data = opts.data;
   }
+  if (_.isArray(opts.initialLayoutClassList)) {
+    opts.initial_layout_class_list = opts.initialLayoutClassList.join(' ');
+  } else if (_.isString(opts.initialLayoutClassList)) {
+    opts.initial_layout_class_list = opts.initialLayoutClassList;
+  }
   tokenData = _.pick(_.defaults(opts, {
     session_id: sessionId,
     create_time: now,
     expire_time: now + (60 * 60 * 24), // 1 day
     nonce: Math.random(),
-    role: 'publisher'
-  }), 'session_id', 'create_time', 'nonce', 'role', 'expire_time', 'connection_data');
+    role: 'publisher',
+    initial_layout_class_list: '',
+  }), 'session_id', 'create_time', 'nonce', 'role', 'expire_time', 'connection_data',
+  'initial_layout_class_list');
 
   // validate tokenData
   if (!_.includes(['publisher', 'subscriber', 'moderator'], tokenData.role)) {
@@ -573,6 +580,10 @@ OpenTok.prototype.generateToken = function (sessionId, opts) {
   if (tokenData.connection_data &&
       (tokenData.connection_data.length > 1024 || !_.isString(tokenData.connection_data))) {
     throw new Error('Invalid data for token generation, must be a string with maximum length 1024');
+  }
+  if (tokenData.initial_layout_class_list && tokenData.initial_layout_class_list.length > 1024) {
+    throw new Error('Invalid initial layout class list for token generation, must have ' +
+                    'concatenated length of less than 1024');
   }
 
   return encodeToken(tokenData, this.apiKey, this.apiSecret);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opentok",
   "description": "OpenTok server-side SDK",
-  "version": "2.5.1-alpha.1",
+  "version": "2.6.0",
   "homepage": "https://github.com/opentok/opentok-node",
   "repository": {
     "type": "git",

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -756,6 +756,35 @@ describe('#generateToken', function () {
     expect(decoded.expire_time).to.equal(Math.round(fractionalExpireTime).toString());
   });
 
+  it('sets initial layout class list in the token', function() {
+    var layoutClassList = ['focus', 'inactive'];
+    var singleLayoutClass = 'focus';
+
+    var layoutBearingToken = this.opentok.generateToken(this.sessionId, {
+      initialLayoutClassList: layoutClassList
+    });
+    expect(layoutBearingToken).to.be.a('string');
+    expect(helpers.verifyTokenSignature(layoutBearingToken, apiSecret)).to.be.true
+    var decoded = helpers.decodeToken(layoutBearingToken);
+    expect(decoded.initial_layout_class_list).to.equal(layoutClassList.join(' '));
+
+    var singleLayoutBearingToken = this.opentok.generateToken(this.sessionId, {
+      initialLayoutClassList: singleLayoutClass
+    });
+    expect(singleLayoutBearingToken).to.be.a('string');
+    expect(helpers.verifyTokenSignature(singleLayoutBearingToken, apiSecret)).to.be.true
+    decoded = helpers.decodeToken(singleLayoutBearingToken);
+    expect(decoded.initial_layout_class_list).to.equal(singleLayoutClass);
+
+    // NOTE: ignores invalid options instead of throwing an error, except if its too long
+  });
+
+  it('complains if the sessionId is not valid', function() {
+    expect(function() {
+      this.opentok.generateToken();
+    }).to.throw(Error);
+  });
+
   it('sets connection data in the token', function () {
     // expects a token with a connection data to have it
     var sampleData = 'name=Johnny';


### PR DESCRIPTION
#### What is this PR doing?

Adding an `initialLayoutClassList` option to the OpenTok.generateToken() method.

#### How should this be manually tested?

1. Create a routed session.
2. Create a token for the session using opentok.generateToken(sessionId, {initialLayoutClassList: ['focus']}.
3. In a supported client, connect to the session using the token, and publish a stream.
4. Use the OpenTok REST API to start a broadcast with the layout type set to `verticalPresentation ` (see https://tokbox.com/developer/rest/#start_broadcast).
5. View the resulting broadcast and note that the video is shown in the "focus" position.

Note that there are also tests written (run `grunt`).