### PR TITLE
Remove the info parameter from the connect callback

### DIFF
--- a/sample/Archiving/public/js/host.js
+++ b/sample/Archiving/public/js/host.js
@@ -2,7 +2,7 @@ var session = OT.initSession(sessionId),
     publisher = OT.initPublisher("publisher"),
     archiveID = null;
 
-session.connect(apiKey, token, function(err, info) {
+session.connect(apiKey, token, function(err) {
   if(err) {
     alert(err.message || err);
   }

--- a/sample/Archiving/public/js/participant.js
+++ b/sample/Archiving/public/js/participant.js
@@ -1,7 +1,7 @@
 var session = OT.initSession(sessionId),
     publisher = OT.initPublisher("publisher");
 
-session.connect(apiKey, token, function(err, info) {
+session.connect(apiKey, token, function(err) {
   if(err) {
     alert(err.message || err);
   }


### PR DESCRIPTION
#### What is this PR doing?

Remove the info parameter from the connect callback. We don't need it anymore.

#### How should this be manually tested?

Make sure the archiving demo still works.
