### PR TITLE
Update JS samples and references to Client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The OpenTok Node SDK lets you generate
 [OpenTok](http://www.tokbox.com/) applications, and
 [archive](https://tokbox.com/opentok/tutorials/archiving) OpenTok sessions.
 
+If you are looking for the JavaScript Client SDK please see the [@opentok/client](https://www.npmjs.com/package/@opentok/client) NPM module.
+
 # Installation using npm (recommended):
 
 npm helps manage dependencies for node projects. Find more info here: <http://npmjs.org>

--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -620,7 +620,7 @@ OpenTok.prototype.createSession = function (opts, callback) {
 *              streams, and signal. (This is the default value if you do not specify a role.)</li>
 *
 *           <li> <code>'moderator'</code> &mdash; In addition to the privileges granted to a
-*             publisher, in clients using the OpenTok.js 2.2 library, a moderator can call the
+*             publisher, in clients using the OpenTok.js library, a moderator can call the
 *             <code>forceUnpublish()</code> and <code>forceDisconnect()</code> method of the
 *             Session object.</li>
 *        </ul>

--- a/sample/Archiving/public/js/host.js
+++ b/sample/Archiving/public/js/host.js
@@ -1,8 +1,8 @@
-var session = OT.initSession(sessionId),
+var session = OT.initSession(apiKey, sessionId),
     publisher = OT.initPublisher("publisher"),
     archiveID = null;
 
-session.connect(apiKey, token, function(err) {
+session.connect(token, function(err) {
   if(err) {
     alert(err.message || err);
   }

--- a/sample/Archiving/public/js/participant.js
+++ b/sample/Archiving/public/js/participant.js
@@ -1,7 +1,7 @@
-var session = OT.initSession(sessionId),
+var session = OT.initSession(apiKey, sessionId),
     publisher = OT.initPublisher("publisher");
 
-session.connect(apiKey, token, function(err) {
+session.connect(token, function(err) {
   if(err) {
     alert(err.message || err);
   }

--- a/sample/Archiving/views/host.ejs
+++ b/sample/Archiving/views/host.ejs
@@ -1,6 +1,6 @@
 <% include header %>
 
-<script src="//static.opentok.com/webrtc/v2.2/js/opentok.min.js"></script>
+<script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
 
   <div class="container bump-me">
 

--- a/sample/Archiving/views/participant.ejs
+++ b/sample/Archiving/views/participant.ejs
@@ -1,6 +1,6 @@
 <% include header %>
 
-<script src="//static.opentok.com/webrtc/v2.2/js/opentok.min.js"></script>
+<script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
 
   <div class="container bump-me">
 

--- a/sample/HelloWorld/public/js/helloworld.js
+++ b/sample/HelloWorld/public/js/helloworld.js
@@ -1,8 +1,8 @@
 // Initialize an OpenTok Session object
-var session = TB.initSession(sessionId);
+var session = OT.initSession(apiKey, sessionId);
 
 // Initialize a Publisher, and place it into the element with id="publisher"
-var publisher = TB.initPublisher(apiKey, 'publisher');
+var publisher = OT.initPublisher('publisher');
 
 // Attach event handlers
 session.on({
@@ -29,4 +29,4 @@ session.on({
 });
 
 // Connect to the Session using the 'apiKey' of the application and a 'token' for permission
-session.connect(apiKey, token);
+session.connect(token);

--- a/sample/HelloWorld/views/index.ejs
+++ b/sample/HelloWorld/views/index.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title>OpenTok Hello World</title>
-    <script src="//static.opentok.com/webrtc/v2.2/js/TB.min.js"></script>
+    <script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
     <script type="text/javascript">
         var apiKey = '<%= apiKey %>';
         var sessionId = '<%= sessionId %>';

--- a/sample/SipInterconnect/views/index.ejs
+++ b/sample/SipInterconnect/views/index.ejs
@@ -40,7 +40,7 @@
     var token = "<%= token %>";
     var apiKey = "<%= apiKey %>";
 
-    var session = OT.initSession(sessionId);
+    var session = OT.initSession(apiKey, sessionId);
     session.on("streamCreated", function (event) {
       var tokenData = event.stream.connection.data;
       if (tokenData && tokenData.includes("sip=true")) {
@@ -50,7 +50,7 @@
       }
       session.subscribe(event.stream, element, { insertMode: "append" });
     })
-    .connect(apiKey, token, function (err) {
+    .connect(token, function (err) {
       if (err) return;
       session.publish("selfPublisherContainer", {
         insertMode: "append",


### PR DESCRIPTION
- Point users to the Client SDK on NPM in case that's what they're looking for.
- Update samples to use latest client SDK API and CDN URL