### PR TITLE
Add Composed Archiving resolution parameter on creation (OPENTOK-36017)

### DIFF
--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -89,6 +89,16 @@ var api;
 *   URL for 10 minutes. To generate a new URL, call the {@link OpenTok#getArchive OpenTok.getArchive()} or
 *   {@link OpenTok#listArchives OpenTok.listArchives()} method.
 *
+* @property {String} resolution
+*   The resolution to be used for Composed Archiving and Broadcasting. This parameter should not be passed
+*   for Individual archives (doing so will result in an error). The following resolutions are supported:
+*   <ul>
+*     <li>"640x480" -- SD archiving output</li>
+*     <li>"1270x720" -- HD archiving output</li>
+*   </ul>
+*   Note: this property is set only for Composed Archiving and Broadcasting.
+*   See the {@link OpenTok#startArchive OpenTok.startArchive()} method.
+*
 * @see {@link OpenTok#deleteArchive OpenTok.deleteArchive()}
 * @see {@link OpenTok#getArchive OpenTok.getArchive()}
 * @see {@link OpenTok#startArchive OpenTok.startArchive()}
@@ -234,7 +244,8 @@ exports.startArchive = function (config, sessionId, options, callback) {
     name: options.name,
     hasAudio: options.hasAudio,
     hasVideo: options.hasVideo,
-    outputMode: options.outputMode
+    outputMode: options.outputMode,
+    resolution: options.resolution
   }, function startArchiveCallback(err, response, body) {
     if (err) {
       callback(err);

--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -94,7 +94,7 @@ var api;
 *   for Individual archives (doing so will result in an error). The following resolutions are supported:
 *   <ul>
 *     <li>"640x480" -- SD archiving output</li>
-*     <li>"1270x720" -- HD archiving output</li>
+*     <li>"1280x720" -- HD archiving output</li>
 *   </ul>
 *   Note: this property is set only for Composed Archiving and Broadcasting.
 *   See the {@link OpenTok#startArchive OpenTok.startArchive()} method.

--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -90,14 +90,6 @@ var api;
 *   {@link OpenTok#listArchives OpenTok.listArchives()} method.
 *
 * @property {String} resolution
-*   The resolution to be used for Composed Archiving and Broadcasting. This parameter should not be passed
-*   for Individual archives (doing so will result in an error). The following resolutions are supported:
-*   <ul>
-*     <li>"640x480" -- SD archiving output</li>
-*     <li>"1280x720" -- HD archiving output</li>
-*   </ul>
-*   Note: this property is set only for Composed Archiving and Broadcasting.
-*   See the {@link OpenTok#startArchive OpenTok.startArchive()} method.
 *
 * @see {@link OpenTok#deleteArchive OpenTok.deleteArchive()}
 * @see {@link OpenTok#getArchive OpenTok.getArchive()}


### PR DESCRIPTION
#### What is this PR doing?
It adds the resolution field in the archive, so that we can enable clients to start composers with different resolutions. The supported till now are "1280x720" and "640x480".

#### How should this be manually tested?
I tested it by modifying the sample archiving app. Used the "tbdev" environment, where this feature is enabled.

#### What are the relevant tickets?
OPENTOK-36017