### PR TITLE
add ability to pass from field for sip dial

### DIFF
--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -890,6 +890,11 @@ OpenTok.prototype.dial = function (sessionId, token, sipUri, options, callback) 
   if (options.secure) {
     body.sip.secure = !!options.secure;
   }
+
+  if (options.from && _.isString(options.from)) {
+    body.sip.from = options.from;
+  }
+
   this.client.dial(body, function (err, json) {
     if (err) return callback(new Error('Failed to dial endpoint. ' + err));
     return callback(null, new SipInterconnect(self, json));

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -1112,6 +1112,49 @@ describe('#dial', function () {
     );
   });
 
+  it('dials a SIP gateway and adds a from field', function (done) {
+    var scope = nock('https://api.opentok.com:443')
+      .matchHeader('x-opentok-auth', function (value) {
+        try {
+          jwt.verify(value, apiSecret, { issuer: apiKey });
+          return true;
+        }
+        catch (error) {
+          done(error);
+          return false;
+        }
+      })
+      .matchHeader('user-agent', new RegExp('OpenTok-Node-SDK/' + pkg.version))
+      .post('/v2/project/123456/dial', {
+        sessionId: this.sessionId,
+        token: this.token,
+        sip: {
+          uri: goodSipUri,
+          from: '15551115555'
+        }
+      })
+      .reply(200, {
+        id: 'CONFERENCEID',
+        connectionId: 'CONNECTIONID',
+        streamId: 'STREAMID'
+      });
+    this.opentok.dial(
+      this.sessionId, this.token, goodSipUri, { from: '15551115555' },
+      function (err, sipCall) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(sipCall).to.be.an.instanceof(SipInterconnect);
+        expect(sipCall.id).to.equal('CONFERENCEID');
+        expect(sipCall.streamId).to.equal('STREAMID');
+        expect(sipCall.connectionId).to.equal('CONNECTIONID');
+        scope.done();
+        done(err);
+      }
+    );
+  });
+
   it('complains if sessionId, token, SIP URI, or callback are missing or invalid', function () {
     // Missing all params
     expect(function () {

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -1149,8 +1149,7 @@ describe('#dial', function () {
         expect(sipCall.id).to.equal('CONFERENCEID');
         expect(sipCall.streamId).to.equal('STREAMID');
         expect(sipCall.connectionId).to.equal('CONNECTIONID');
-        scope.done();
-        done(err);
+        done();
       }
     );
   });


### PR DESCRIPTION
#### What is this PR doing?
Adds the ability to pass in the `from` field as a part of the `options` object for the `dial` method

#### How should this be manually tested?
Dial out and add `from` as a part of the options
#### What are the relevant tickets?
#197 
