### PR TITLE
Parse JSON error in listStreams

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -298,13 +298,14 @@ Client.prototype.listStreams = function listStreams(sessionId, cb) {
     .replace(/<%sessionId%>/g, sessionId);
   request.get({
     url: url,
+    json: true,
     headers: this.generateHeaders()
   }, function requestCallback(err, resp, body) {
     if (err) {
       return cb(new Error('The request failed: ' + err));
     }
     if (resp.statusCode === 200) {
-      return cb(null, JSON.parse(body).items.map(function itemIterator(item) {
+      return cb(null, body.items.map(function itemIterator(item) {
         return new Stream(JSON.stringify(item));
       }));
     }

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -108,7 +108,11 @@ function mockStreamRequest(sessId, streamId, status) {
 
 function mockListStreamsRequest(sessId, status) {
   var body;
-  if (!status) {
+  if (status) {
+    body = JSON.stringify({
+      message: 'error message'
+    });
+  } else {
     body = JSON.stringify({
       count: 1,
       items: [
@@ -1603,6 +1607,7 @@ describe('listStreams', function () {
       mockListStreamsRequest(SESSIONID, 400);
       opentok.listStreams(SESSIONID, function (err, streams) {
         expect(err).to.not.be.null;
+        expect(err.message).to.contain('error message');
         expect(streams).to.be.undefined;
         done();
       });


### PR DESCRIPTION
This change parses the JSON response from the server.

Previous behaviour was that `error` ended up being `new Error('404 undefined')` since body was a string.