### PR TITLE
Correction to SIP docs

### DIFF
--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -900,8 +900,7 @@ OpenTok = function (apiKey, apiSecret, env) {
   * <ul>
   *   <li>
   *     <code>headers</code> (Object) &mdash; Custom headers to be added to the SIP INVITE
-  *     request iniated from OpenTok to the third-party SIP platform. All headers must start
-  *     with the "X-" prefix, or a Bad Request (400) will be thrown.
+  *     request iniated from OpenTok to the third-party SIP platform.
   *   </li>
   *   <li>
   *     <code>auth</code> (Object) &mdash; The credentials to be used for HTTP Digest authentication


### PR DESCRIPTION
"X-" prefix for custom headers no longer required

#### What is this PR doing?
Correcting some docs.

#### How should this be manually tested?
Run jsdoc.

#### What are the relevant tickets?
None.
