### PR TITLE
Fix error reporting on client for startBroadcast and setStreamClassLists

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -129,7 +129,7 @@ Client.prototype.startBroadcast = function (opts, cb) {
       return cb(null, JSON.stringify(body));
     }
 
-    return cb(new Error('(' + resp.statusCode + ') ' + body));
+    return cb(new Error('(' + resp.statusCode + ') ' + JSON.stringify(body)));
   });
 };
 
@@ -236,7 +236,7 @@ Client.prototype.setStreamClassLists = function setStreamClassLists(sessionId, c
       default:
         if (resp.statusCode >= 500 && resp.statusCode <= 599) {
           // handle server errors
-          return cb(new Error('A server error occurred: (' + resp.statusCode + ') ' + body));
+          return cb(new Error('A server error occurred: (' + resp.statusCode + ') ' + JSON.stringify(body)));
         }
     }
     return cb(new Error('An unexpected error occurred: (' + resp.statusCode + ') ' + JSON.stringify(body)));

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -1275,7 +1275,7 @@ describe('#startBroadcast', function () {
     }
   };
 
-  function mockStartBroadcastRequest(sessId, status) {
+  function mockStartBroadcastRequest(sessId, status, optionalBody) {
     var body;
     var broadcastObj;
     if (!status) {
@@ -1285,7 +1285,7 @@ describe('#startBroadcast', function () {
     }
     nock('https://api.opentok.com')
       .post('/v2/project/APIKEY/broadcast')
-      .reply(status || 200, body);
+      .reply(status || 200, body || optionalBody);
   }
 
   afterEach(function () {
@@ -1328,9 +1328,9 @@ describe('#startBroadcast', function () {
   });
 
   it('results in error a response other than 200', function (done) {
-    mockStartBroadcastRequest(SESSIONID, 400);
+    mockStartBroadcastRequest(SESSIONID, 400, { error: 'remote error message' });
     opentok.startBroadcast(SESSIONID, options, function (err, broadcast) {
-      expect(err).not.to.be.null;
+      expect(err.message).to.equal('Failed to start broadcast. Error: (400) {"error":"remote error message"}');
       expect(broadcast).to.be.undefined;
       done();
     });


### PR DESCRIPTION
The error message currently only contains [object Object], which make integration harder to debug.

#### What is this PR doing?
This is a minor fix on the error messages.

#### How should this be manually tested?
A unit test was added to cover the `startBroadcast` case.

#### What are the relevant tickets?
There is none.
