### PR TITLE
Fix JS issues / increase error usefulness

### DIFF
--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -233,7 +233,7 @@ exports.listArchives = function (config, options, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
         }
       }
       else {
@@ -291,11 +291,11 @@ exports.startArchive = function (ot, config, sessionId, options, callback) {
           callback(new errors.ArchiveError('Recording already in progress or session not using OpenTok Media Router'));
         }
         else {
-          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
         }
       }
       else if (body.status !== 'started') {
-        callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
+        callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
       }
       else {
         callback(null, new Archive(config, body));
@@ -332,7 +332,7 @@ exports.stopArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
         }
       }
       else {
@@ -372,7 +372,7 @@ exports.getArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
         }
       }
       else {
@@ -393,8 +393,8 @@ function patchArchive(config, archiveId, options, callback) {
 
   if (options.addStream && options.addStream.length > 0) {
     options = {
-      hasAudio: options.hasAudio ?? true,
-      hasVideo: options.hasVideo ?? true,
+      hasAudio: options.hasAudio != null ? options.hasAudio : true,
+      hasVideo: options.hasVideo != null ? options.hasVideo : true,
       addStream: options.addStream
     };
   }
@@ -415,7 +415,7 @@ function patchArchive(config, archiveId, options, callback) {
     function patchArchiveCallback(err, response, body) {
       if (err || response.statusCode !== 200) {
         if (response && response.statusCode === 400) {
-          callback(new errors.ArgumentError(`Invalid request: ${body}`));
+          callback(new errors.ArgumentError('Invalid request: ' + JSON.stringify(body)));
         }
         else if (response && response.statusCode === 403) {
           callback(new errors.AuthError('Invalid API key or secret'));
@@ -427,7 +427,7 @@ function patchArchive(config, archiveId, options, callback) {
           callback(new errors.ArchiveError('Unsupported Stream Mode'));
         }
         else {
-          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
         }
       }
       else {
@@ -456,8 +456,8 @@ exports.addArchiveStream = function (config, archiveId, streamId, archiveOptions
 
   archiveOptions = {
     addStream: streamId,
-    hasAudio: archiveOptions.hasAudio ?? true,
-    hasVideo: archiveOptions.hasVideo ?? true
+    hasAudio: archiveOptions.hasAudio != null ? archiveOptions.hasAudio : true,
+    hasVideo: archiveOptions.hasVideo != null ? archiveOptions.hasVideo : true
   };
 
   patchArchive(config, archiveId, archiveOptions, callback);
@@ -501,7 +501,7 @@ exports.deleteArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
         }
       }
       else {

--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -233,7 +233,7 @@ exports.listArchives = function (config, options, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok'));
+          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
         }
       }
       else {
@@ -291,11 +291,11 @@ exports.startArchive = function (ot, config, sessionId, options, callback) {
           callback(new errors.ArchiveError('Recording already in progress or session not using OpenTok Media Router'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok'));
+          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
         }
       }
       else if (body.status !== 'started') {
-        callback(new errors.RequestError('Unexpected response from OpenTok'));
+        callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
       }
       else {
         callback(null, new Archive(config, body));
@@ -332,7 +332,7 @@ exports.stopArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok'));
+          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
         }
       }
       else {
@@ -372,7 +372,7 @@ exports.getArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok'));
+          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
         }
       }
       else {
@@ -393,8 +393,8 @@ function patchArchive(config, archiveId, options, callback) {
 
   if (options.addStream && options.addStream.length > 0) {
     options = {
-      hasAudio: options.hasAudio || true,
-      hasVideo: options.hasVideo || true,
+      hasAudio: options.hasAudio ?? true,
+      hasVideo: options.hasVideo ?? true,
       addStream: options.addStream
     };
   }
@@ -412,10 +412,10 @@ function patchArchive(config, archiveId, options, callback) {
     'PATCH',
     '/archive/' + encodeURIComponent(archiveId) + '/streams',
     options,
-    function patchArchiveCallback(err, response) {
+    function patchArchiveCallback(err, response, body) {
       if (err || response.statusCode !== 200) {
         if (response && response.statusCode === 400) {
-          callback(new errors.ArgumentError('Invalid request'));
+          callback(new errors.ArgumentError(`Invalid request: ${body}`));
         }
         else if (response && response.statusCode === 403) {
           callback(new errors.AuthError('Invalid API key or secret'));
@@ -427,7 +427,7 @@ function patchArchive(config, archiveId, options, callback) {
           callback(new errors.ArchiveError('Unsupported Stream Mode'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok'));
+          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
         }
       }
       else {
@@ -456,8 +456,8 @@ exports.addArchiveStream = function (config, archiveId, streamId, archiveOptions
 
   archiveOptions = {
     addStream: streamId,
-    hasAudio: archiveOptions.hasAudio || true,
-    hasVideo: archiveOptions.hasVideo || true
+    hasAudio: archiveOptions.hasAudio ?? true,
+    hasVideo: archiveOptions.hasVideo ?? true
   };
 
   patchArchive(config, archiveId, archiveOptions, callback);
@@ -492,7 +492,7 @@ exports.deleteArchive = function (config, archiveId, callback) {
     'DELETE',
     '/archive/' + encodeURIComponent(archiveId),
     null,
-    function deleteArchiveCallback(err, response) {
+    function deleteArchiveCallback(err, response, body) {
       if (err || response.statusCode !== 204) {
         if (response && response.statusCode === 404) {
           callback(new errors.ArchiveError('Archive not found'));
@@ -501,7 +501,7 @@ exports.deleteArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok'));
+          callback(new errors.RequestError(`Unexpected response from OpenTok: ${body}`));
         }
       }
       else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opentok",
   "description": "OpenTok server-side SDK",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "homepage": "https://github.com/opentok/opentok-node",
   "repository": {
     "type": "git",

--- a/spec/opentok_spec.js
+++ b/spec/opentok_spec.js
@@ -169,7 +169,7 @@ describe('Archiving', function () {
 
       opentok.startArchive(mockSessionId, function (err) {
         expect(err).not.toBeNull();
-        expect(err.message).toBe('Unexpected response from OpenTok');
+        expect(err.message).toBe('Unexpected response from OpenTok: {"message":"responseString"}');
         done();
       });
     });
@@ -375,7 +375,7 @@ describe('Archiving', function () {
 
       opentok.getArchive(mockArchiveId, function (err) {
         expect(err).not.toBeNull();
-        expect(err.message).toBe('Unexpected response from OpenTok');
+        expect(err.message).toBe('Unexpected response from OpenTok: {"message":"Something went wrong"}');
         done();
       });
     });
@@ -459,7 +459,7 @@ describe('Archiving', function () {
         expect(archives).toBeUndefined();
         expect(total).toBeUndefined();
         expect(err).not.toBeNull();
-        expect(err.message).toBe('Unexpected response from OpenTok');
+        expect(err.message).toBe('Unexpected response from OpenTok: {"message":"Some error"}');
         done();
       });
     });
@@ -604,7 +604,7 @@ describe('Archiving', function () {
       opentok.stopArchive(mockArchiveId, function (err, archive) {
         expect(archive).toBeUndefined();
         expect(err).not.toBeNull();
-        expect(err.message).toBe('Unexpected response from OpenTok');
+        expect(err.message).toBe('Unexpected response from OpenTok: {"message":"Some other error."}');
         done();
       });
     });
@@ -671,7 +671,7 @@ describe('Archiving', function () {
 
       opentok.deleteArchive(mockArchiveId, function (err) {
         expect(err).not.toBeNull();
-        expect(err.message).toBe('Unexpected response from OpenTok');
+        expect(err.message).toBe('Unexpected response from OpenTok: "{ \\"message\\" : \\"Some other error.\\" }"');
         done();
       });
     });


### PR DESCRIPTION
#### What is this PR doing?
Insures that archiving options are respected for false attributes.
Increases verbosity of errors from archiving requests for better debugging.

#### How should this be manually tested?
Start archive in manual mode and make sure addStream options are respected in terms of audio/video components.

#### What are the relevant tickets?
https://video-api.support.vonage.com/hc/en-us/requests/1990354
