### PR TITLE
Added multiArchiveTag to startArchive

### DIFF
--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -114,6 +114,11 @@ var generateHeaders = function generateHeaders(config) {
 *   the URL for 10 minutes. To generate a new URL, call the
 *   {@link OpenTok#getArchive OpenTok.getArchive()} or
 *   {@link OpenTok#listArchives OpenTok.listArchives()} method.
+* 
+* @property {String} multiArchiveTag
+*   The tag of the archive, with which to start. This is unique for each archive within session. 
+*   <code>multiArchiveTag</code> is not case-sensitive (e.g. 'MyArchive' and 'myarchive' are 
+*   treated as same)
 *
 * @see {@link OpenTok#deleteArchive OpenTok.deleteArchive()}
 * @see {@link OpenTok#getArchive OpenTok.getArchive()}

--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -114,11 +114,16 @@ var generateHeaders = function generateHeaders(config) {
 *   the URL for 10 minutes. To generate a new URL, call the
 *   {@link OpenTok#getArchive OpenTok.getArchive()} or
 *   {@link OpenTok#listArchives OpenTok.listArchives()} method.
-* 
+*
 * @property {String} multiArchiveTag
-*   The tag of the archive, with which to start. This is unique for each archive within session. 
-*   <code>multiArchiveTag</code> is not case-sensitive (e.g. 'MyArchive' and 'myarchive' are 
-*   treated as same)
+*  Set this to support recording multiple archives for the same session simultaneously. Set
+*  this to a unique string for each simultaneous archive of an ongoing session. You must also
+*  set this option when manually starting an archive that is automatically archived. Note that
+*  the multiArchiveTag value is not included in the response for the methods to list archives
+*  and retrieve archive information. If you do not specify a unique multiArchiveTag, you can
+*  only record one archive at a time for a given session.
+*  See <a href="https://tokbox.com/developer/guides/archiving/#simultaneous-archives">
+*  Simultaneous archives</a>.
 *
 * @see {@link OpenTok#deleteArchive OpenTok.deleteArchive()}
 * @see {@link OpenTok#getArchive OpenTok.getArchive()}

--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -273,7 +273,8 @@ exports.startArchive = function (ot, config, sessionId, options, callback) {
       hasVideo: options.hasVideo,
       outputMode: options.outputMode,
       layout: options.layout,
-      resolution: options.resolution
+      resolution: options.resolution,
+      multiArchiveTag: options.multiArchiveTag
     },
     function startArchiveCallback(err, response, body) {
       if (err) {

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -81,6 +81,14 @@
 *     <li><code>hasAudio</code> -- Whether the stream's audio is included in the broadcast.
 *     <li><code>hasVideo</code> -- Whether the stream's video is included in the broadcast.
 *   </ul>
+*
+* @property {String} multiBroadcastTag
+*    Set this to support multiple broadcasts for the same session simultaneously. Set this
+*    to a unique string for each simultaneous broadcast of an ongoing session.
+*    Note that the <code>multiBroadcastTag</code> value is not included in the response
+*    for the methods to list live streaming broadcasts and get information about a live
+*    streaming broadcast.
+*
 * @see {@link OpenTok#getBroadcast OpenTok.getBroadcast()}
 * @see {@link OpenTok#startBroadcast OpenTok.startBroadcast()}
 * @see {@link OpenTok#stopBroadcast OpenTok.stopBroadcast()}

--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -199,6 +199,11 @@ OpenTok = function (apiKey, apiSecret, env) {
   *          {@link OpenTok#removeArchiveStream OpenTok.removeArchiveStream()} methods.</li>
   *       </ul>
   *   </li>
+  *   <li>
+  *     <code>multiArchiveTag</code> (String) &mdash; The tag of the archive, with which to start, 
+  *     this is unique for each archive within session. <code>multiArchiveTag</code> is not 
+  *     case-sensitive (e.g. 'MyArchive' and 'myarchive' are treated as same)
+  *   </li>
   * </ul>
   *
   * For more information on archiving and the archive file formats, see the

--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -200,9 +200,14 @@ OpenTok = function (apiKey, apiSecret, env) {
   *       </ul>
   *   </li>
   *   <li>
-  *     <code>multiArchiveTag</code> (String) &mdash; The tag of the archive, with which to start, 
-  *     this is unique for each archive within session. <code>multiArchiveTag</code> is not 
-  *     case-sensitive (e.g. 'MyArchive' and 'myarchive' are treated as same)
+  *     <code>multiArchiveTag</code> (String) &mdash; Set this to support recording
+  *     multiple archives for the same session simultaneously. Set this to a unique string
+  *     for each simultaneous archive of an ongoing session. You must also set this option
+  *     when manually starting an archive that is automatically archived. Note that the
+  *     <code>multiArchiveTag</code> value is not included in the response for
+  *     the methods to list archives and retrieve archive information. If you do not specify a
+  *     unique <code>multiArchiveTag</code> you can only record one archive at a time for a
+  *     given session.
   *   </li>
   * </ul>
   *
@@ -602,6 +607,14 @@ OpenTok = function (apiKey, apiSecret, env) {
    *          {@link OpenTok#addBroadcastStream OpenTok.addBroadcastStream()} and
    *          {@link OpenTok#removeBroadcastStream OpenTok.removeBroadcastStream()} methods.</li>
    *       </ul>
+   *   </li>
+   *   <li>
+   *        <code>multiBroadcastTag</code> (optional) &mdash; Set this to support multiple
+   *        broadcasts for the same session simultaneously. Set this to a unique string for
+   *        each simultaneous broadcast of an ongoing session.
+   *        Note that the <code>multiBroadcastTag</code> value is not included in the response
+   *        for the methods to list live streaming broadcasts and get information about a live
+   *        streaming broadcast.
    *   </li>
    * </ul>
    *


### PR DESCRIPTION
#### What is this PR doing?

This updates `startArchive` to accept in the `multiArchiveTag` parameter.

#### How should this be manually tested?
```js
opentok.startArchive(
    sessionId, 
    {
        name: 'My awesome session',
        multiArchiveTag: 'tagging this session',
    },
    (err, archive) => {
        if (err) {
            console.err(err);
            return;
        }

        console.log(archive);
);
```

#### What are the relevant tickets?

[DEVX-6489](https://jira.vonage.com/browse/DEVX-6489)
