### PR TITLE
fix: Bad request on callback deletion

### DIFF
--- a/lib/archiving.js
+++ b/lib/archiving.js
@@ -240,7 +240,7 @@ exports.listArchives = function (config, options, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
         }
       }
       else {
@@ -299,11 +299,11 @@ exports.startArchive = function (ot, config, sessionId, options, callback) {
           callback(new errors.ArchiveError('Recording already in progress or session not using OpenTok Media Router'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
         }
       }
       else if (body.status !== 'started') {
-        callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
+        callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
       }
       else {
         callback(null, new Archive(config, body));
@@ -340,7 +340,7 @@ exports.stopArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
         }
       }
       else {
@@ -380,7 +380,7 @@ exports.getArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
         }
       }
       else {
@@ -435,7 +435,7 @@ function patchArchive(config, archiveId, options, callback) {
           callback(new errors.ArchiveError('Unsupported Stream Mode'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
         }
       }
       else {
@@ -509,7 +509,7 @@ exports.deleteArchive = function (config, archiveId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body)));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
         }
       }
       else {

--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -107,7 +107,8 @@ exports.unregisterCallback = function (config, callbackId, callback) {
     return;
   }
   api(
-    config, 'DELETE', '/callback/' + encodeURIComponent(callbackId), {},
+    config, 'DELETE', '/callback/' + encodeURIComponent(callbackId),
+    null,
     function (err, response, body) {
       if (err) {
         callback(err);

--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -54,7 +54,7 @@ exports.listCallbacks = function (config, options, callback) {
         callback(new errors.AuthError('Invalid API key or secret'));
       }
       else {
-        callback(new errors.RequestError('Unexpected response from OpenTok'));
+        callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
       }
     }
     else {
@@ -89,7 +89,7 @@ exports.registerCallback = function (config, options, callback) {
         callback(new errors.AuthError('Invalid API key or secret'));
       }
       else {
-        callback(new errors.RequestError('Unexpected response from OpenTok'));
+        callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
       }
     }
     else {
@@ -108,7 +108,7 @@ exports.unregisterCallback = function (config, callbackId, callback) {
   }
   api(
     config, 'DELETE', '/callback/' + encodeURIComponent(callbackId), {},
-    function (err, response) {
+    function (err, response, body) {
       if (err) {
         callback(err);
       }
@@ -120,7 +120,7 @@ exports.unregisterCallback = function (config, callbackId, callback) {
           callback(new errors.AuthError('Invalid API key or secret'));
         }
         else {
-          callback(new errors.RequestError('Unexpected response from OpenTok'));
+          callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
         }
       }
       else {

--- a/lib/moderation.js
+++ b/lib/moderation.js
@@ -28,7 +28,7 @@ exports.forceDisconnect = function (config, sessionId, connectionId, callback) {
   if (sessionId == null || connectionId == null) {
     return callback(new errors.ArgumentError('No sessionId or connectionId tiven to signal'));
   }
-  return api(config, 'DELETE', sessionId, connectionId, null, function (err, response) {
+  return api(config, 'DELETE', sessionId, connectionId, null, function (err, response, body) {
     if (err || Math.floor(response.statusCode / 100) !== 2) {
       if (response && response.statusCode === 403) {
         callback(new errors.AuthError('Invalid API key or secret'));
@@ -37,7 +37,7 @@ exports.forceDisconnect = function (config, sessionId, connectionId, callback) {
         callback(new errors.ForceDisconnectError('Session or Connection not found'));
       }
       else {
-        callback(new errors.RequestError('Unexpected response from OpenTok'));
+        callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
       }
     }
     else {

--- a/lib/signaling.js
+++ b/lib/signaling.js
@@ -34,7 +34,7 @@ exports.signal = function (config, sessionId, connectionId, payload, callback) {
   if (sessionId == null || payload == null) {
     return callback(new errors.ArgumentError('No sessionId or payload given to signal'));
   }
-  return api(config, 'POST', sessionId, connectionId, payload, function (err, response) {
+  return api(config, 'POST', sessionId, connectionId, payload, function (err, response, body) {
     if (err || Math.floor(response.statusCode / 100) !== 2) {
       if (response && response.statusCode === 403) {
         callback(new errors.AuthError('Invalid API key or secret'));
@@ -43,7 +43,7 @@ exports.signal = function (config, sessionId, connectionId, payload, callback) {
         callback(new errors.SignalError('Session or Connection not found'));
       }
       else {
-        callback(new errors.RequestError('Unexpected response from OpenTok'));
+        callback(new errors.RequestError('Unexpected response from OpenTok: ' + JSON.stringify(body || { statusCode: response.statusCode, statusMessage: response.statusMessage })));
       }
     }
     else {


### PR DESCRIPTION
#### What is this PR doing?

1) Adding details of what when wrong when an `Unexpected response from OpenTok` occurred.
2) Fixing a bug where the method `unregisterCallback` would reject with a `400 - Bad Request` because the body was not null.

#### How should this be manually tested?

Steps:
1. create a callback using `registerCallback` 
2. then remove it using `unregisterCallback`

#### What are the relevant tickets?

- https://github.com/opentok/opentok-node/issues/290