### PR TITLE
fix: Patch requests to broadcasts now watch for 204 instead of 200

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -295,7 +295,7 @@ Client.prototype.patchBroadcast = function patchBroadcast(broadcastId, opts, cb)
     headers: this.generateHeaders()
   }, function (err, resp, body) {
     if (err) return cb(new Error('The request failed'));
-    if (resp.statusCode === 200) {
+    if (resp.statusCode === 204) {
       return cb(null, JSON.stringify(body));
     }
     return cb(new Error('(' + resp.statusCode + ') ' + JSON.stringify(body)));

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -1586,7 +1586,7 @@ describe('#patchBroadcast', function () {
   function mockPatchBroadcastRequest(broadcastId, optionalBody, status) {
     nock('https://api.opentok.com')
       .patch('/v2/project/APIKEY/broadcast/' + broadcastId + '/streams')
-      .reply(200 || status, optionalBody);
+      .reply(204 || status, optionalBody);
   }
 
   afterEach(function () {


### PR DESCRIPTION
#### What is this PR doing?
Changes `PATCH` requests to watch for a 204 status code instead of a 200 response code, per https://tokbox.com/developer/rest/#selecting-broadcast-streams

#### How should this be manually tested?
Try adding a stream to an existing broadcast

#### What are the relevant tickets?
Came in via support
