### PR TITLE
Fix formatting issue in jsdoc reference

### DIFF
--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -648,8 +648,10 @@ OpenTok = function (apiKey, apiSecret, env) {
   this.stopRender = render.stopRender.bind(null, apiConfig);
 
   /**
-   * Starts a <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/">live
-   * streaming broadcast</a>.
+   * Starts a live streaming broadcast.
+   * For more information, see the 
+   * <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/">live streaming broadcast</a>
+   * developer guide.
    *
    * @param {String} sessionId The ID of the session to broadcast.
    *


### PR DESCRIPTION
The method table does not like <a> tags in the intro sentence.

#### What is this PR doing?
Fixing a formatting issue in the jsdoc content.

#### How should this be manually tested?
N/A

#### What are the relevant tickets?
N/A