### PR TITLE
docs: adding documentation for client options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -37,7 +37,8 @@ var defaultConfig = {
   },
   auth: {
     expire: 300
-  }
+  },
+  uaAddendum: null
 };
 
 var Client = function (c) {

--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -62,8 +62,19 @@ function decodeSessionId(sessionId) {
  *
  * @param apiKey {String} Your OpenTok API key. (See your
  * <a href="https://tokbox.com/account">TokBox account page</a>.)
+ *
  * @param apiSecret {String} Your OpenTok API secret. (See your
  * <a href="https://tokbox.com/account">TokBox account page</a>.)
+ *
+ * @param env {Object} Configuration options for the client with the following options
+ * (all of which are optional)
+ * <p>
+ *   <ul>
+ *     <li> <code>apiUrl</code> (String) &mdash; Custom url to use for the API</li>
+ *     <li> <code>uaAddendum</code> (String) &mdash; string to append to the UserAgent</li>
+ *     <li> <code>timeout<code> (Integer) &mdash; Time in milliseconds to timeout request</li>
+ *   </ul>
+ * </p>
  */
 // eslint-disable-next-line consistent-return
 OpenTok = function (apiKey, apiSecret, env) {
@@ -111,6 +122,7 @@ OpenTok = function (apiKey, apiSecret, env) {
       clientConfig.apiUrl = env.apiUrl;
       apiConfig.apiEndpoint = env.apiUrl;
     }
+    // This is not used
     if (_.isString(env.proxy)) {
       clientConfig.request.proxy = env.proxy;
       apiConfig.proxy = env.proxy;
@@ -1046,7 +1058,6 @@ OpenTok = function (apiKey, apiSecret, env) {
       }
     );
   };
-
 
   /**
    * Sets (or updates) the layout of the broadcast. See


### PR DESCRIPTION
The "string" option was left out intentionally as I am not sure how it will be rendered in the docs



