### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Reference documentation is available at <https://tokbox.com/developer/sdks/node/
 You need an OpenTok API key and API secret, which you can obtain by logging into your
 [TokBox account](https://tokbox.com/account).
 
-The OpenTok Node SDK requires Node.js 6 or higher. It may work on older versions but they are no longer tested.
+The OpenTok Node SDK requires Node.js 14 or higher. It may work on older versions but they are no longer tested.
 
 ## Release Notes
 


### PR DESCRIPTION
Requires node14 min as optional chaining is used.

https://github.com/opentok/opentok-node/blob/88e261875c2eecd11478d9a0587823a81fd18a0e/lib/archiving.js#L364

#### What is this PR doing?
Informing about breaking node version

#### How should this be manually tested?
By changing the node-version

#### What are the relevant tickets?
NA
