### PR TITLE
fix: map error when items is not defined for list streams

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -410,7 +410,7 @@ Client.prototype.listStreams = function listStreams(sessionId, cb) {
     method: 'GET',
     headers: this.generateHeaders(),
     callback: (err, body) => {
-      cb(err, body?.items.map((stream) => new Stream(JSON.stringify(stream))))
+      cb(err, body?.items?.map((stream) => new Stream(JSON.stringify(stream))) || [])
     },
   });
 };

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -2292,6 +2292,18 @@ describe('listStreams', function () {
       });
     });
 
+    it('should not error when items is missing in response', function (done) {
+      nock('https://api.opentok.com')
+        .get('/v2/project/123456/session/' + SESSIONID + '/stream')
+        .reply(200, { count: 0 }, { 'Content-Type': 'application/json' });
+
+      opentok.listStreams(SESSIONID, function (err, streams) {
+        expect(err).to.be.null;
+        expect(streams).to.empty;
+        done();
+      });
+    });
+
     it('should return an error if sessionId is null', function (done) {
       opentok.listStreams(null, function (err, streams) {
         expect(err).to.not.be.null;


### PR DESCRIPTION
#### What is this PR doing?

Fixing an issue when the API does not return the `items` when listing streams

#### How should this be manually tested?


#### What are the relevant tickets?

