### PR TITLE
Swapped to JWT tokens

### DIFF
--- a/lib/generateJwt.js
+++ b/lib/generateJwt.js
@@ -1,13 +1,16 @@
 var jwt = require('jsonwebtoken');
 
-module.exports = function (config) {
+module.exports = function (config, additionalClaims) {
   var currentTime = Math.floor(new Date() / 1000);
-  var token = jwt.sign({
+  const initialClaims = {
     iss: config.apiKey,
     ist: 'project',
     iat: currentTime,
-    exp: currentTime + config.auth.expire
-  }, config.apiSecret);
+    exp: additionalClaims?.expire_time || currentTime + config.auth.expire
+  };
+
+  const claims = {...initialClaims, ...additionalClaims};
+  const token = jwt.sign(claims, config.apiSecret);
 
   return token;
 };

--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -2128,7 +2128,7 @@ OpenTok.prototype.createSession = function (opts, callback) {
 * @return The token string.
 */
 
-OpenTok.prototype.generateToken = function (sessionId, opts) {
+OpenTok.prototype.generateToken = function (sessionId, opts, generateT1Token = false) {
   var decoded;
   var tokenData;
   var now = Math.round(new Date().getTime() / 1000);
@@ -2207,8 +2207,12 @@ OpenTok.prototype.generateToken = function (sessionId, opts) {
         + 'concatenated length of less than 1024');
   }
 
-  return encodeToken(tokenData, this.apiKey, this.apiSecret);
-
+  if (generateT1Token) {
+    return encodeToken(tokenData, this.apiKey, this.apiSecret);
+  }
+  
+  tokenData.scope = 'session.connect';
+  return generateJwt(this.client.c, tokenData);
 };
 
 /*


### PR DESCRIPTION
#### What is this PR doing?
Changes the Node SDK to using JWTs for generating client-side tokens, with a fallback to T1 tokens if requested. The fallback _is not_ documented and should only be used if the user runs into issues and support ends up contacting engineering or devrel.


#### How should this be manually tested?
Build a token and try in the playground. There are automated tests with this change.


#### What are the relevant tickets?
DEVX-8989

