### PR TITLE
feat: Add bidirectional flag in websocket connect [VIDMC-1226] 

### DIFF
--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -1348,6 +1348,10 @@ OpenTok = function (apiKey, apiSecret, env) {
       body.websocket.headers = options.headers;
     }
 
+    if (options.bidirectional) {
+      body.websocket.bidirectional = options.bidirectional;
+    }
+
     this.client.websocketConnect(body, function (err, json) {
       if (err) return callback(new Error('Error connecting to websocket: ' + err.message));
       return callback(null, json);

--- a/test/opentok-test.js
+++ b/test/opentok-test.js
@@ -1821,6 +1821,49 @@ describe('#websocketconnect', function () {
     );
   });
 
+  it('connect to a websocket with bidirectional enabled', function (done) {
+    var scope = nock('https://api.opentok.com:443')
+      .matchHeader('x-opentok-auth', function (value) {
+        try {
+          jwt.verify(value[0], apiSecret, { issuer: apiKey });
+          return true;
+        }
+        catch (error) {
+          done(error);
+          return false;
+        }
+      })
+      .matchHeader('user-agent', new RegExp('OpenTok-Node-SDK/' + pkg.version))
+      .post('/v2/project/123456/connect', {
+        sessionId: this.sessionId,
+        token: this.token,
+        websocket: {
+          uri: goodWebsocketUri,
+          bidirectional: true
+        }
+      })
+      .reply(200, {
+        id: 'CONFERENCEID',
+        connectionId: 'CONNECTIONID'
+      });
+    this.opentok.websocketConnect(
+      this.sessionId,
+      this.token,
+      goodWebsocketUri,
+      { bidirectional: true },
+      function (err, connect) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(connect.id).to.equal('CONFERENCEID');
+        expect(connect.connectionId).to.equal('CONNECTIONID');
+        scope.done();
+        done(err);
+      }
+    );
+  });
+
   it('complains if sessionId, token, Websocket URI, or callback are missing or invalid', function () {
     // Missing all params
     expect(function () {


### PR DESCRIPTION
#### What is this PR doing?
This PR adds a new flag in the websocket connect api, which enables/disables this feature for the user.

#### How should this be manually tested?
By enabling this flag, user should be able to send the data from the websocket server back in to the opentok session. Previously it was only in one direction.

#### What are the relevant tickets?
https://jira.vonage.com/browse/VIDMC-1226
