### PR TITLE
chore: Version bump to 2.23.2 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentok",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentok",
-      "version": "2.23.1",
+      "version": "2.23.2",
       "license": "MIT",
       "dependencies": {
         "@vonage/jwt": "1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opentok",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "OpenTok server-side SDK",
   "homepage": "https://github.com/opentok/opentok-node",
   "bugs": {


### PR DESCRIPTION
#### What is this PR doing?
Version bump for 2.23.2 release

#### How should this be manually tested?


#### What are the relevant tickets?

